### PR TITLE
redirect stderr to stdout in every line in script file

### DIFF
--- a/lib/try_hook.rb
+++ b/lib/try_hook.rb
@@ -6,7 +6,7 @@ class BashTryHook < Mumukit::Templates::TryHook
   end
 
   def compile_file_content(r)
-    <<bash
+    <<bash.split("\n").map { |it| "#{it} 2>&1" }.join("\n")
 echo #{extra_separator}
 #{r.extra}
 echo #{cookie_separator}

--- a/spec/try_spec.rb
+++ b/spec/try_spec.rb
@@ -35,6 +35,14 @@ describe BashTryHook do
     it { expect(result[2][:status]).to eq :failed }
   end
 
+  context 'try with cd to invalid directory - multiple times' do
+    let(:request) { struct query: 'cat nonexistent_directory', goal: goal }
+    let(:results) { Array.new(5) { hook.run! hook.compile(request) } }
+
+    it { expect(results.map { |it| it[2][:result] }).to all eq 'cat: nonexistent_directory: No such file or directory' }
+    it { expect(results.map { |it| it[2][:status] }).to all eq :failed }
+  end
+
   context 'try with multiline outputs' do
     let(:goal) { { query_outputs: { query: 'echo -e "goal1\ngoal2"', output: "goal1\ngoal2" } } }
     let(:request) { struct query: 'echo -e "query1\nquery2"', extra: 'echo -e "extra1\nextra2"', cookie: ['echo -e "cookie1\ncookie2"'], goal: goal }

--- a/spec/try_spec.rb
+++ b/spec/try_spec.rb
@@ -37,7 +37,7 @@ describe BashTryHook do
 
   context 'try with cd to invalid directory - multiple times' do
     let(:request) { struct query: 'cat nonexistent_directory', goal: goal }
-    let(:results) { Array.new(5) { hook.run! hook.compile(request) } }
+    let(:results) { 5.times.map { hook.run! hook.compile(request) } }
 
     it { expect(results.map { |it| it[2][:result] }).to all eq 'cat: nonexistent_directory: No such file or directory' }
     it { expect(results.map { |it| it[2][:status] }).to all eq :failed }


### PR DESCRIPTION
This seems like a somewhat absurd solution but it's the only thing I could come up with that seems to work.
I tried doing the redirection in the command line method (doing "bash #{filename} 2>&1") but that didn't seem to work either.

I also don't know how to test this other than by hand since pretty much the problem was that this was introducing non-deterministic behavior.

Anyways, it seems to work fine now ¯\\(°_o)/¯

Fixes #12. 
Fixes #18.